### PR TITLE
Revert "testing relative urls for ci"

### DIFF
--- a/themes/polar/templates/base.html
+++ b/themes/polar/templates/base.html
@@ -201,7 +201,7 @@
 
 			 {% if LINKS %}
 				{% for name, link in LINKS %}
-                	&nbsp;&sdot;&nbsp;<a href="{{ SITEURL }}{{ link }}">{{ name }}</a></li>
+                	&nbsp;&sdot;&nbsp;<a href="{{ link }}">{{ name }}</a></li>
             	{% endfor %}
             {% endif %}
 


### PR DESCRIPTION
Reverts DLR-AMR/t8code-website#15
This seems to break all our footer links.