### PR TITLE
Replace "Trixi" -> "Trixi.jl"

### DIFF
--- a/content/pages/2_showcase.html
+++ b/content/pages/2_showcase.html
@@ -110,14 +110,14 @@
 						<div class="row">
 							<div class="col-md-6">
 								<h2 class="title">
-                  Collaboration with Trixi - a numerical simulation framework for hyperbolic conservation laws written in Julia
+                  Collaboration with Trixi.jl - a numerical simulation framework for hyperbolic conservation laws written in Julia
 								</h2>
 
-                <p> The <a href="https://trixi-framework.github.io/Trixi.jl"
-                  target="_blank">Trixi framework</a> is a numerical simulation framework for a
+                <p> <a href="https://trixi-framework.github.io/Trixi.jl"
+                  target="_blank">Trixi.jl</a> is a numerical simulation framework for a
                   huge variety of hyperbolic conservation laws and is written in <a
                   href="https://julialang.org" target="_blank"> Julia </a>.  Key objective is to
-                  pave the way for dynamical-adaptive, hybrid, curvilinear meshes in Trixi by
+                  pave the way for dynamical-adaptive, hybrid, curvilinear meshes in Trixi.jl by
                   interfacing with t8code. Scalable management of hybrid meshes - the combination of
                   different element types (triangles, quadrilaterals, tetraeders, hexaeders,
                   pyramids, etc.) into one single datastructure - is a unique feature of t8code,
@@ -131,7 +131,7 @@
 							<div class="galerry-item">
                                 <img src="images/showcase/khi-trixi-t8code.png" alt="img 1">
                                 <a href="images/showcase/khi-trixi-t8code.png" class="boxer"><span class="item-title">
-          Snapshot of a Kelvin-Helmholtz-Instability simulation computed with Trixi and a dynamically-adaptive, curvilinear mesh managed by t8code </span></a>
+          Snapshot of a Kelvin-Helmholtz-Instability simulation computed with Trixi.jl and a dynamically-adaptive, curvilinear mesh managed by t8code </span></a>
                             </div>
 						</div><!-- /.row -->
 					</div><!-- /.container -->


### PR DESCRIPTION
When referring to the software package, please always use "Trixi.jl" (including the ".jl").